### PR TITLE
Only use rdflib core namespace (non-polluting)

### DIFF
--- a/funowl/literals.py
+++ b/funowl/literals.py
@@ -171,7 +171,7 @@ class Literal(FunOwlChoice):
         # Create a turtle triple to use the n3 parser
         # TODO: make the constructor static and use clear
         stmt = f'@prefix : <{DUMMY_PREFIX}> . @prefix xsd: <{XSD}> . :f a {v} .'
-        g = Graph()
+        g = Graph(bind_namespaces="core")
         try:
             g.parse(data=stmt, format="turtle")
         except BadSyntax:

--- a/funowl/prefix_declarations.py
+++ b/funowl/prefix_declarations.py
@@ -51,7 +51,9 @@ class PrefixDeclarations(NamespaceManager):
     def __init__(self, g: Optional[Graph] = None) -> None:
         self._init = True
         self._prefixMap: Dict[str, Prefix] = dict()
-        super().__init__(g or Graph())
+        if g is None:
+            g = Graph(bind_namespaces="core")
+        super().__init__(g, bind_namespaces="core")
         for prefix in PREFIX_PRESETS:
             self.bind(prefix.prefixName, prefix.fullIRI)
         self._init = False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,5 +13,5 @@ SKIP_LONG_TESTS = True
 
 # rdflib 6.1.1 has a LONG list of pre-assigned prefixes.  This breaks some of our tests and the rdflib
 # community promises to fix it (some day...).  For now, we won't run tests on this version
-RDFLIB_PREFIXES_ARE_BROKEN = rdflib.__version__ >= "6.1.1"
+RDFLIB_PREFIXES_ARE_BROKEN = rdflib.__version__ == "6.1.1"
 PREFIXES_BROKEN_MESSAGE = "rdflib 6.1.1+ emits a LOT of prefixes.  Test skipped!"


### PR DESCRIPTION
Fixes #34
